### PR TITLE
Update `init_state_` to fit with changes in NEST

### DIFF
--- a/src/pif_psc_alpha.cpp
+++ b/src/pif_psc_alpha.cpp
@@ -182,10 +182,8 @@ mynest::pif_psc_alpha::pif_psc_alpha( const pif_psc_alpha& n )
  * ---------------------------------------------------------------- */
 
 void
-mynest::pif_psc_alpha::init_state_( const Node& proto )
+mynest::pif_psc_alpha::init_state_()
 {
-  const auto& pr = downcast< pif_psc_alpha >( proto );
-  S_ = pr.S_;
 }
 
 void

--- a/src/pif_psc_alpha.h
+++ b/src/pif_psc_alpha.h
@@ -142,7 +142,7 @@ private:
   //! Reset parameters and state of neuron.
 
   //! Reset state of neuron.
-  void init_state_( const Node& proto ) override;
+  void init_state_() override;
 
   //! Reset internal buffers of neuron.
   void init_buffers_() override;


### PR DESCRIPTION
This fixes #14.

`init_state_` is now empty in `pif_psc_alpha`. Let me know if I should remove it completely. I let it stay so that it was easier to see it, but it is removed for all models where it is not needed in NEST.