### PR TITLE
Fix macos build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Install Python
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/build.sh
+++ b/build.sh
@@ -49,13 +49,6 @@ cd ..
 git clone https://github.com/nest/nest-simulator.git
 cd nest-simulator
 
-PYTHON_INCLUDE_DIR=`python3 -c "import sysconfig; print(sysconfig.get_path('include'))"`
-PYLIB_BASE=lib`basename $PYTHON_INCLUDE_DIR`
-PYLIB_DIR=$(dirname `sed 's/include/lib/' <<< $PYTHON_INCLUDE_DIR`)
-PYTHON_LIBRARY=`find $PYLIB_DIR \( -name $PYLIB_BASE.so -o -name $PYLIB_BASE.dylib \) -print -quit`
-echo "--> Detected PYTHON_LIBRARY=$PYTHON_LIBRARY"
-echo "--> Detected PYTHON_INCLUDE_DIR=$PYTHON_INCLUDE_DIR"
-
 # Explicitly allow MPI oversubscription. This is required by Open MPI versions > 3.0.
 # Not having this in place leads to a "not enough slots available" error.
 NEST_RESULT=result
@@ -71,8 +64,6 @@ cmake \
     -Dwith-optimize=ON -Dwith-warning=ON \
     $CONFIGURE_MPI \
     $CONFIGURE_OPENMP \
-    -DPYTHON_LIBRARY=$PYTHON_LIBRARY \
-    -DPYTHON_INCLUDE_DIR=$PYTHON_INCLUDE_DIR \
     -DCMAKE_INSTALL_PREFIX=$NEST_RESULT\
     ..
 
@@ -86,9 +77,6 @@ cmake \
     -Dwith-nest=$NEST_RESULT/bin/nest-config \
     $CONFIGURE_MPI \
     $CONFIGURE_OPENMP \
-    -DPYTHON_LIBRARY=$PYTHON_LIBRARY \
-    -DPYTHON_INCLUDE_DIR=$PYTHON_INCLUDE_DIR \
-    -DCMAKE_INSTALL_PREFIX=$NEST_RESULT \
     ..
 
 VERBOSE=1 make -j 2


### PR DESCRIPTION
The CI build for MacOs is failing for the following error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/runner/work/nest-extension-module/nest-simulator/result/lib/python3.10/site-packages/nest/__init__.py", line 53, in <module>
    from .ll_api import KernelAttribute  # noqa
  File "/Users/runner/work/nest-extension-module/nest-simulator/result/lib/python3.10/site-packages/nest/ll_api.py", line 51, in <module>
    from . import pynestkernel as kernel      # noqa
ImportError: dlopen(/Users/runner/work/nest-extension-module/nest-simulator/result/lib/python3.10/site-packages/nest/pynestkernel.so, 10): Symbol not found: _PyDescr_IsData
  Referenced from: /Users/runner/work/nest-extension-module/nest-simulator/result/lib/python3.10/site-packages/nest/pynestkernel.so
  Expected in: flat namespace
 in /Users/runner/work/nest-extension-module/nest-simulator/result/lib/python3.10/site-packages/nest/pynestkernel.so
```
This is because `cmake` is not finding the correct python version installed using the `setup-python` action. This PR updates the action version from `setup-python@v2` to `setup-python@v4`, fixing the build failure.