### PR TITLE
Update .readthedocs.yml for new `build.os` syntax

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,7 @@ sphinx:
   builder: html
   configuration: doc/conf.py
 
-python:
-   version: 3.8
-
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"


### PR DESCRIPTION
This is required to run on Read The Docs due to the change of configuration format.