### PR TITLE
Revise to adjust to transition from modelsmodule to models in NEST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required( VERSION 2.8.12 )
+cmake_minimum_required( VERSION 3.19 )
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 include( ProcessDependencies )

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,8 @@ NEST Extension Module Example
 
 .. attention::
 
-   Please note that the code in this repository is compatible with NEST master
-   (aka 3.0) only. For earlier versions of NEST, see the extension module example
-   in ``examples/MyModule`` of any NEST 2.x source distribution.
+   This version of the extension module code will not work with NEST
+   3.6 or earlier. It is adapted to NEST Master as of 15 December 2023.
 
 This repository contains an example extension module (i.e a "plugin") for
 the `NEST Simulator <https://nest-simulator.org>`_. Extension modules allow

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,8 @@
 # Exit shell if any subcommand or pipline returns a non-zero status.
 set -e
 
+# THIS BUILD SCRIPT IS OUTDATED!
+
 # We need to do this, because  update-alternatives is not available on MacOS
 if [ "$xNEST_BUILD_COMPILER" = "CLANG" ]; then
     export CC=clang-11

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,8 +20,8 @@
 # Add all your sources here and specify dependencies, e.g., link libraries
 set( MODULE_SOURCES
      mymodule.h mymodule.cpp
-     pif_psc_alpha.cpp pif_psc_alpha.h
-     drop_odd_spike_connection.h
+     pif_psc_alpha.h pif_psc_alpha.cpp
+     drop_odd_spike_connection.h drop_odd_spike_connection.cpp
      step_pattern_builder.h step_pattern_builder.cpp
      recording_backend_socket.h recording_backend_socket.cpp
    )

--- a/src/drop_odd_spike_connection.cpp
+++ b/src/drop_odd_spike_connection.cpp
@@ -1,0 +1,32 @@
+/*
+ *  drop_odd_spike_connection.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "drop_odd_spike_connection.h"
+
+// Includes from nestkernel:
+#include "nest_impl.h"
+
+void
+mynest::register_drop_odd_spike_connection( const std::string& name )
+{
+  nest::register_connection_model< DropOddSpikeConnection >( name );
+}

--- a/src/drop_odd_spike_connection.h
+++ b/src/drop_odd_spike_connection.h
@@ -29,6 +29,7 @@
 
 namespace mynest
 {
+  void register_drop_odd_spike_connection( const std::string& name );
 
 /** @BeginDocumentation
   Name: drop_odd_spike - Synapse dropping spikes with odd time stamps.
@@ -132,8 +133,9 @@ public:
    * @param e The event to send
    * @param t Thread
    * @param cp Common properties to all synapses.
+   * @returns True if spike is transmitted, false otherwise.
    */
-  void send( nest::Event& e, size_t t, const CommonPropertiesType& cp );
+  bool send( nest::Event& e, size_t t, const CommonPropertiesType& cp );
 
   // The following methods contain mostly fixed code to forward the
   // corresponding tasks to corresponding methods in the base class and the w_
@@ -162,12 +164,12 @@ template < typename targetidentifierT >
 constexpr nest::ConnectionModelProperties DropOddSpikeConnection< targetidentifierT >::properties;
 
 template < typename targetidentifierT >
-inline void
+inline bool
 DropOddSpikeConnection< targetidentifierT >::send( nest::Event& e, size_t t, const CommonPropertiesType& props )
 {
   if ( e.get_stamp().get_steps() % 2 ) // stamp is odd, drop it
   {
-    return;
+    return false;
   }
 
   // Even time stamp, we send the spike using the normal sending mechanism
@@ -177,6 +179,8 @@ DropOddSpikeConnection< targetidentifierT >::send( nest::Event& e, size_t t, con
   e.set_receiver( *ConnectionBase::get_target( t ) );
   e.set_rport( ConnectionBase::get_rport() );
   e(); // this sends the event
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/src/mymodule.cpp
+++ b/src/mymodule.cpp
@@ -109,21 +109,13 @@ mynest::MyModule::init( SLIInterpreter* i )
   /* Register a neuron or device model.
      Give node type as template argument and the name as second argument.
   */
-  nest::kernel().model_manager.register_node_model< pif_psc_alpha >( "pif_psc_alpha" );
+  register_pif_psc_alpha( "pif_psc_alpha" );
 
   /* Register a synapse type.
      Give synapse type as template argument and the name as second argument.
-
-     There are two choices for the template argument:
-         - nest::TargetIdentifierPtrRport
-         - nest::TargetIdentifierIndex
-     The first is the standard and you should usually stick to it.
-     nest::TargetIdentifierIndex reduces the memory requirement of synapses
-     even further, but limits the number of available rports. Please see
-     Kunkel et al, Front Neurofinfom 8:78 (2014), Sec 3.3.2, for details.
   */
-  nest::register_connection_model< DropOddSpikeConnection >( "drop_odd_synapse" );
-
+  register_drop_odd_spike_connection( "drop_odd_synapse" );
+  
   // Register connection rule.
   nest::kernel().connection_manager.register_conn_builder< StepPatternBuilder >( "step_pattern" );
 

--- a/src/pif_psc_alpha.cpp
+++ b/src/pif_psc_alpha.cpp
@@ -31,6 +31,7 @@
 // Includes from nestkernel:
 #include "exceptions.h"
 #include "kernel_manager.h"
+#include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
 // Includes from sli:
@@ -47,6 +48,12 @@ using namespace nest;
  * ---------------------------------------------------------------- */
 
 nest::RecordablesMap< mynest::pif_psc_alpha > mynest::pif_psc_alpha::recordablesMap_;
+
+void
+mynest::register_pif_psc_alpha( const std::string& name )
+{
+  register_node_model< pif_psc_alpha >( name );
+}
 
 namespace nest
 {

--- a/src/pif_psc_alpha.h
+++ b/src/pif_psc_alpha.h
@@ -36,6 +36,7 @@
 
 namespace mynest
 {
+  void register_pif_psc_alpha( const std::string& name );
 
 /** @BeginDocumentation
 Name: pif_psc_alpha - Perfect integrate-and-fire neuron model with alpha PSC


### PR DESCRIPTION
This PR provides a version of the extension module that is compatible with NEST after the transition from modelsmodule to models [#2990](https://github.com/nest/nest-simulator/pull/2990). It should thus indicate also what changes are needed to NESTML-generated models and modules.

The module is still a SLI module, since that is needed for loading. We need to revise the module loading mechanism in NEST to change this.