### PR TITLE
Adapt CMake setup for extension module to refactoring in NEST

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           mkdir build && cd build
           cmake \
               -Dwith-optimize=ON -Dwith-warning=ON \
-              -Dwith-nest=$NEST_RESULT/bin/nest-config \
+              -Dwith-nest=$NEST_RESULT \
               $CONFIGURE_MPI \
               $CONFIGURE_OPENMP \
               ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,28 +31,44 @@ set( MODULE_VERSION_MINOR 1 )
 set( MODULE_VERSION "${MODULE_VERSION_MAJOR}.${MODULE_VERSION_MINOR}" )
 
 if ( with-nest )
-   set( NEST_CONFIG ${with-nest} )
+   # NESTSimulator_ROOT is the variable CMake's find_package() itself looks
+   # for (CMP0074) to locate NESTSimulatorConfig.cmake -- no need to fold it
+   # into CMAKE_PREFIX_PATH by hand.
+   set( NESTSimulator_ROOT "${with-nest}" )
+   set( NEST_CONFIG "${NESTSimulator_ROOT}/bin/nest-config" )
 else ()
-   message( FATAL_ERROR "-Dwith-nest=<nest_config> is required" )
+   message( FATAL_ERROR "-Dwith-nest=<path_to_nest_installation> is required" )
 endif ()
 
-# Use `nest-config` to get the compiler that was used for NEST.
+# Use `nest-config` to get the compiler that was used for NEST. Needed before
+# project() can run, so this -- and the basic check that `nest-config` is
+# actually reachable under the given root -- cannot go through find_package().
 execute_process(
     COMMAND ${NEST_CONFIG} --compiler
     RESULT_VARIABLE RES_VAR
     OUTPUT_VARIABLE NEST_COMPILER
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-
-# One check on first execution, if `nest-config` is working.
 if ( NOT RES_VAR EQUAL 0 )
-  message( FATAL_ERROR "Cannot run `${NEST_CONFIG}`. Please specify correct `nest-config` via -Dwith-nest=... " )
+  message( FATAL_ERROR "Cannot run `${NEST_CONFIG}`. Please specify a valid NEST install prefix via -Dwith-nest=... " )
 endif ()
 
 set( CMAKE_CXX_COMPILER "${NEST_COMPILER}" )
 project( ${MODULE_NAME} CXX )
 
-# Use `nest-config` to get the Python executable (for help generation).
+# Find NEST's CMake CONFIG-mode package (NESTSimulatorConfig.cmake), hinted
+# by NESTSimulator_ROOT above. Provides the NEST::nest target (compile
+# features, include dirs, link libraries -- the Darwin "dynamic_lookup" link
+# option is already part of the target, so no separate APPLE-specific
+# handling is needed here as it used to be with `nest-config --libs`).
+find_package( NESTSimulator REQUIRED )
+
+# Same install prefix find_package() just used -- no nest-config call needed.
+set( NEST_INSTALL_PREFIX "${NESTSimulator_ROOT}" )
+
+# Everything below is information `nest-config` provides that the CONFIG
+# package above does not (yet): the Python interpreter NEST was built
+# against, and its install layout for docs/data/libs.
 execute_process(
     COMMAND ${NEST_CONFIG} --python-executable
     RESULT_VARIABLE RES_VAR
@@ -60,7 +76,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Get the Python executable (for help generation).
 execute_process(
     COMMAND ${NEST_CONFIG} --python-version
     RESULT_VARIABLE RES_VAR
@@ -68,60 +83,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Get the install prefix.
-execute_process(
-    COMMAND ${NEST_CONFIG} --prefix
-    RESULT_VARIABLE RES_VAR
-    OUTPUT_VARIABLE NEST_INSTALL_PREFIX
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# Get the CXXFLAGS.
-execute_process(
-    COMMAND ${NEST_CONFIG} --cflags
-    RESULT_VARIABLE RES_VAR
-    OUTPUT_VARIABLE NEST_CXXFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# Get the Includes.
-execute_process(
-    COMMAND ${NEST_CONFIG} --includes
-    RESULT_VARIABLE RES_VAR
-    OUTPUT_VARIABLE NEST_INCLUDES
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-if ( NEST_INCLUDES )
-  # make a cmake list
-  string( REPLACE " " ";" NEST_INCLUDES_LIST "${NEST_INCLUDES}" )
-  foreach ( inc_complete ${NEST_INCLUDES_LIST} )
-    # if it is actually a -Iincludedir
-    if ( "${inc_complete}" MATCHES "^-I.*" )
-      # get the directory
-      string( REGEX REPLACE "^-I(.*)" "\\1" inc "${inc_complete}" )
-      # and check whether it is a directory
-      if ( IS_DIRECTORY "${inc}" )
-        include_directories( "${inc}" )
-      endif ()
-    endif ()
-  endforeach ()
-endif ()
-
-# Get all linked libraries.
-execute_process(
-    COMMAND ${NEST_CONFIG} --libs
-    RESULT_VARIABLE RES_VAR
-    OUTPUT_VARIABLE NEST_LIBS
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if ( APPLE )
-    # delay lookup of symbols; this is specific for Mac build environment
-    string(APPEND NEST_LIBS " -Wl,-undefined -Wl,dynamic_lookup")
-endif ()
-
-
-# Get the data install dir.
 execute_process(
     COMMAND ${NEST_CONFIG} --datadir
     RESULT_VARIABLE RES_VAR
@@ -129,7 +90,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Get the documentation install dir.
 execute_process(
     COMMAND ${NEST_CONFIG} --docdir
     RESULT_VARIABLE RES_VAR
@@ -137,7 +97,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Get the library install dir.
 execute_process(
     COMMAND ${NEST_CONFIG} --libdir
     RESULT_VARIABLE RES_VAR
@@ -247,12 +206,14 @@ message( "-------------------------------------------------------" )
 message( "${MODULE_NAME} Configuration Summary" )
 message( "-------------------------------------------------------" )
 message( "" )
+get_target_property( NEST_INCLUDES NEST::nest INTERFACE_INCLUDE_DIRECTORIES )
+get_target_property( NEST_LIBS NEST::nest INTERFACE_LINK_LIBRARIES )
+
 message( "C++ compiler         : ${CMAKE_CXX_COMPILER}" )
 message( "Build static libs    : ${NEST_STATIC_LIB}" )
 message( "C++ compiler flags   : ${CMAKE_CXX_FLAGS}" )
-message( "NEST compiler flags  : ${NEST_CXXFLAGS}" )
 message( "NEST include dirs    : ${NEST_INCLUDES}" )
-message( "NEST libraries flags : ${NEST_LIBS}" )
+message( "NEST libraries       : ${NEST_LIBS}" )
 message( "User link libraries  : ${USER_LINK_LIBRARIES}" )
 message( "" )
 message( "-------------------------------------------------------" )

--- a/doc/extension_modules.rst
+++ b/doc/extension_modules.rst
@@ -49,13 +49,14 @@ Building MyModule
       mkdir build-ext
       cd build-ext
 
-2. Configure. The configure process uses the script ``nest-config`` to find out where NEST is installed, where the source code resides, and which compiler options were used for compiling NEST. You should provide it explicitly as a CMake option to be sure for which NEST you are building (and later installing) the module:
+2. Configure. You need to specify the ``NEST_INSTALL_DIR`` so the
+   module can be built for the right NEST binary:
 
    .. code-block:: sh
 
-      cmake -Dwith-nest=${NEST_INSTALL_DIR}/bin/nest-config <path/to/module/source>
+      cmake -Dwith-nest=${NEST_INSTALL_DIR} <path/to/module/source>
 
-   All necessary configuration and compiler flags will be set automatically based on information collected from ``nest-config``. You should not provide any other flags to CMake unless you are absolutely sure about what you are doing.
+   All necessary configuration and compiler flags will be set automatically. You should not provide any other flags to CMake unless you are absolutely sure about what you are doing.
 
 3. Compile and install:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,11 +38,10 @@ else ()
 endif ()
 
 add_library( ${MODULE_NAME}_module MODULE ${MODULE_SOURCES} )
-target_link_libraries(${MODULE_NAME}_module ${USER_LINK_LIBRARIES})
+target_link_libraries( ${MODULE_NAME}_module PRIVATE NEST::nest ${USER_LINK_LIBRARIES} )
+target_compile_definitions( ${MODULE_NAME}_module PRIVATE LTX_MODULE )
 set_target_properties( ${MODULE_NAME}_module
    PROPERTIES
-   COMPILE_FLAGS "${NEST_CXXFLAGS} -DLTX_MODULE"
-   LINK_FLAGS "${NEST_LIBS}"
    PREFIX ""
    OUTPUT_NAME ${MODULE_NAME} )
 install( TARGETS ${MODULE_NAME}_module

--- a/src/pif_psc_alpha.cpp
+++ b/src/pif_psc_alpha.cpp
@@ -24,6 +24,7 @@
 
 // C++ includes:
 #include <limits>
+#include <numbers>
 
 #include "dict_util.h"
 
@@ -203,7 +204,7 @@ mynest::pif_psc_alpha::pre_run_hook()
   // P33_ is 1
 
   // initial value ensure normalization to max amplitude 1.0
-  V_.pscInitialValue = 1.0 * numerics::e / P_.tau_syn;
+  V_.pscInitialValue = 1.0 * std::numbers::e / P_.tau_syn;
 
   // refractory time in steps
   V_.t_ref_steps = Time( Time::ms( P_.t_ref ) ).get_steps();


### PR DESCRIPTION
In a sequence of PRs from #3901 to #3916, the CMake setup for NEST is significantly modernized. The two most important changes for extension modules (and thus NESTML) are:

1. Various functions and constants that used to be provided via `numerics.h` are now taken directly from `std::` (#3916).
2. NEST now supports `FindPackage(NESTSimulator)` and this PR takes that into use, although not fully (#3913).
3. The new mechanism needs `-Dwith-nest=<nest_install_dir>` without any `bin/nest-config`.
Concerning 1, we need to see how smart that change was, maybe we will roll back partly.

Concerning 2, we need to discuss what information we actually need and then see if we at some point can drop nest-config entirely.